### PR TITLE
Fix Dockerfile and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ certs/localhost.crt
 .gitignore
 certs/localhost.csr
 .gitignore
+
+/certs/server.crt
+/certs/server.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ RUN go build -ldflags '-s -w'
 
 FROM alpine:latest
 
-COPY --from=build /build/chat /yalk
+COPY --from=build /build/chat /app/yalk
+COPY --from=build /build/static /app/static
+
+WORKDIR /app
 
 # It is adised to use '0.0.0.0' to allow all incoming connections
 ENV HOST_ADDR="0.0.0.0"
@@ -28,4 +31,4 @@ ENV DB_SSLMODE="disable"
 
 EXPOSE 80 443
 
-CMD ["/yalk"]
+CMD ["/app/yalk"]

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ The setup should be pretty straightforward, feel free to open a PR should there 
   _This will need to be used as the Database address in your **Dockerfile**_
 7. Clone this repo in a user privileged directory
   `git clone https://github.com/Revengeic3/yalk-public.git`
-8. Change directory to `yalk-public\certs`
+8. Change directory to `yalk-public`
 9. Generate the SSL certificates, you can leave all fields empty
-  `openssl req -new -x509 -nodes -out server.crt -keyout server.key`
+  `openssl req -new -x509 -nodes -out certs/server.crt -keyout certs/server.key`
 10. Change directory back one level (root of `yalk-public`) and edit the `Dockerfile` with the correct configuration
 1. Build the container image
   `docker build -f Dockerfile -t revengeic3/yalk:latest .`
 1. Run the container
-  `docker run -p 8080:80 -p 4443:443 revengeic3/yalk:latest`
+  `docker run -v "$PWD"/certs:/app/certs -p 8080:80 -p 4443:443 revengeic3/yalk:latest`
 1. Open your browser to your set address using HTTPS
 1. Login with Username 'admin' and Password 'admin'
 1. Works! 🚀


### PR DESCRIPTION
I forgot to copy `static` directory in the Docker image (sorry), I added `certs/{server.crt,server.key}` to `.gitignore` and so I updated README.md file to bind certs directory in Docker container so you can update them without rebuild the image every time